### PR TITLE
docs(index): refresh root links after domain migration

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -10,231 +10,144 @@
 
 | Role | Start Here |
 |------|------------|
-| **New User** | [Quick Start Guide](README.md#-quick-start) → [Demo Setup](docs/DEMO.md) |
-| **Developer** | [Contributing Guide](CONTRIBUTING.md) → [Architecture](#-architecture--services) |
-| **DevOps** | [Operations](#-operations--deployment) → [Observability](#-observability--monitoring) |
-| **Trader** | [Strategies](#-strategies--trading) → [Risk Management](#-risk--compliance) |
+| **New User** | [Quick Start Guide](README.md#-quick-start) → [Demo Setup](docs/domains/3_operations/demo.md) |
+| **Developer** | [Contributing Guide](CONTRIBUTING.md) → [Infrastructure Index](docs/domains/6_infrastructure/INDEX.md) |
+| **DevOps** | [Operations](docs/domains/3_operations/INDEX.md) → [Observability](docs/domains/3_operations/observability/README.md) |
+| **Trader** | [Trading Index](docs/domains/1_trading/INDEX.md) → [Screener](docs/domains/1_trading/screener.md) |
 | **AI Agent** | [AI Navigation](#-ai-agent-navigation) below |
 
 ---
 
 ## 📋 Documentation Domains
 
-### 🏗️ Architecture & Services
+### 🎯 Trading
 
-**Description**: System design, microservices architecture, and core service documentation.
+**Description**: Strategy research, backtesting, and trading logic.
 
-**Keywords**: architecture, microservices, services, backend, API, FastAPI, Docker, PostgreSQL, Redis
+**Keywords**: trading, strategies, backtesting, algo-engine, screener, inplay, market-data
 
 **Critical Documents**:
-- [Project Structure](README.md#project-structure) - Overview of repository layout
-- [Auth Service](docs/auth-service.md) - Authentication & authorization (Auth0)
-- [User Service](docs/user-service.md) - User management & profiles
-- [Algo Engine](docs/algo-engine.md) - Strategy execution engine
-- [Order Router](docs/order-router.md) - Order management & routing
-- [Market Data](docs/market-data.md) - Real-time & historical data feeds
-- [Billing Service](docs/billing.md) - Subscription & payment processing
-- [Notification Service](docs/notification-service.md) - Multi-channel alerts
-- [Streaming Service](docs/streaming.md) - WebSocket & real-time data
+- [Algo Engine](docs/domains/1_trading/algo-engine.md) - Strategy execution engine
+- [Algo-Order Contract](docs/domains/1_trading/algo-order-contract.md) - Strategy to execution payloads
+- [Screener](docs/domains/1_trading/screener.md) - Market scanning workflows
+- [InPlay](docs/domains/1_trading/inplay.md) - Live trading monitoring
+- [Market Data](docs/domains/1_trading/market-data.md) - Data feeds and inputs
+- [Strategies](docs/domains/1_trading/strategies/) - Strategy catalog & development notes
 
-**Domain Index**: [docs/architecture/INDEX.md](docs/architecture/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/1_trading/INDEX.md](docs/domains/1_trading/INDEX.md)
 
 ---
 
-### 📊 Strategies & Trading
+### ⚡ Execution
 
-**Description**: Trading strategy development, backtesting, research tools, and execution.
+**Description**: Order routing, broker integration, and execution contracts.
 
-**Keywords**: strategies, trading, backtesting, algo, automation, visual-designer, AI-assistant, market-connectors
+**Keywords**: execution, order-router, brokers, risk-rules, algo-order, routing
 
 **Critical Documents**:
-- [Feature Overview](README.md#-feature-overview) - Strategies & research domain status
-- [Algo Engine](docs/algo-engine.md) - Strategy execution & management
-- [Algo-Order Contract](docs/algo-order-contract.md) - Strategy-order integration spec
-- [Screener](docs/screener.md) - Market scanning & opportunity detection
-- [InPlay Service](docs/inplay.md) - Live trading monitoring
+- [Order Router](docs/domains/2_execution/order-router.md) - Order routing service
+- [Algo-Order Contract](docs/domains/2_execution/algo-order-contract.md) - Execution contract spec
 
-**Domain Index**: [docs/strategies/INDEX.md](docs/strategies/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/2_execution/INDEX.md](docs/domains/2_execution/INDEX.md)
 
 ---
 
-### 🔐 Security & Compliance
+### 📈 Operations
 
-**Description**: Authentication, authorization, security best practices, and compliance documentation.
+**Description**: Deployment workflows, observability, metrics, and operational runbooks.
 
-**Keywords**: security, auth, Auth0, compliance, secrets, encryption, RBAC, audit
+**Keywords**: operations, deployment, observability, metrics, alerting, demo, sandbox
 
 **Critical Documents**:
-- [Auth0 Setup](docs/AUTH0_SETUP.md) - Authentication configuration
-- [Auth Service](docs/auth-service.md) - Security architecture
-- [Secrets Management](.secrets.baseline) - Baseline secrets detection
-- [Code of Conduct](CODE_OF_CONDUCT.md) - Community standards
+- [Demo Setup](docs/domains/3_operations/demo.md) - End-to-end demo environment
+- [MVP Sandbox Flow](docs/domains/3_operations/mvp-sandbox-flow.md) - Sandbox validation
+- [Observability Stack](docs/domains/3_operations/observability/README.md) - Logs, traces, dashboards
+- [Alerting Runbook](docs/domains/3_operations/operations/alerting.md) - Notifications & incident flow
+- [Metrics Overview](docs/domains/3_operations/metrics/README.md) - KPI reporting
 
-**Domain Index**: [docs/security/INDEX.md](docs/security/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/3_operations/INDEX.md](docs/domains/3_operations/INDEX.md)
 
 ---
 
-### 📈 Observability & Monitoring
+### 🏢 Platform
 
-**Description**: Logging, metrics, tracing, dashboards, and system health monitoring.
+**Description**: Authentication, user management, billing, and shared platform services.
 
-**Keywords**: observability, monitoring, metrics, logs, traces, Prometheus, Grafana, alerts, SRE
+**Keywords**: platform, auth, users, billing, marketplace, notifications, streaming, social
 
 **Critical Documents**:
-- [Observability Overview](docs/observability/README.md) - Monitoring stack setup
-- [Dashboards](docs/observability/dashboards/) - Grafana dashboard configs
-- [Metrics](docs/metrics/) - Custom metrics & KPIs
+- [Auth Service](docs/domains/4_platform/auth-service.md) - Authentication & sessions
+- [User Service](docs/domains/4_platform/user-service.md) - Accounts & profiles
+- [Billing](docs/domains/4_platform/billing.md) - Subscriptions & payments
+- [Marketplace](docs/domains/4_platform/marketplace.md) - Strategy listings
+- [Notification Service](docs/domains/4_platform/notification-service.md) - Alerts delivery
+- [Streaming Service](docs/domains/4_platform/streaming.md) - Real-time updates
+- [Social Features](docs/domains/4_platform/social.md) - Social & collaboration
 
-**Domain Index**: [docs/observability/INDEX.md](docs/observability/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/4_platform/INDEX.md](docs/domains/4_platform/INDEX.md)
 
 ---
 
-### 🚀 Operations & Deployment
+### 🎨 WebApp
 
-**Description**: Deployment guides, infrastructure setup, CI/CD, and operational procedures.
+**Description**: Web dashboard UI, SPA architecture, and design system guidance.
 
-**Keywords**: deployment, DevOps, CI/CD, Docker, docker-compose, infrastructure, operations, maintenance
+**Keywords**: webapp, ui, dashboard, spa, design-system, frontend
 
 **Critical Documents**:
-- [Quick Start](README.md#-quick-start) - Development environment setup
-- [Demo Guide](docs/DEMO.md) - Complete demo environment
-- [Native Development](README.md#native-host-development) - Host-based setup
-- [Operations Docs](docs/operations/) - Operational procedures
-- [Makefile](Makefile) - Common development & deployment tasks
+- [UI Design System](docs/domains/5_webapp/ui/README.md) - Tokens & layout guidelines
+- [Dashboard SPA Overview](docs/domains/5_webapp/ui/web-dashboard-spa-overview.md) - Shell architecture
+- [Dashboard Data Contracts](docs/domains/5_webapp/ui/dashboard-data-contracts.md) - Frontend payloads
+- [Dashboard Modernization](docs/domains/5_webapp/ui/dashboard-modernization.md) - Upgrade roadmap
 
-**Domain Index**: [docs/operations/INDEX.md](docs/operations/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/5_webapp/INDEX.md](docs/domains/5_webapp/INDEX.md)
 
 ---
 
-### 🎓 Tutorials & Guides
+### 🏗️ Infrastructure
 
-**Description**: Step-by-step tutorials, how-to guides, and learning resources.
+**Description**: Docker, migrations, and infrastructure configuration.
 
-**Keywords**: tutorials, guides, learning, examples, how-to, getting-started, onboarding
+**Keywords**: infrastructure, docker, migrations, timescaledb, redis, prometheus, grafana
 
 **Critical Documents**:
-- [Getting Started Guide](docs/help/guides/getting-started.md) - First steps
-- [Tutorials](docs/tutorials/) - Step-by-step walkthroughs
-- [FAQ](docs/help/faq/) - Frequently asked questions
-- [Webinars](docs/help/webinars/) - Video tutorials & recordings
-- [Notebooks](docs/help/notebooks/) - Jupyter notebook examples
+- [Infrastructure Index](docs/domains/6_infrastructure/INDEX.md) - Full infra reference
+- [Docker Compose](docker-compose.yml) - Core service orchestration
+- [Migration Config](infra/migrations/alembic.ini) - Alembic setup
+- [Migrations](infra/migrations/) - Database schema history
+- [Prometheus Config](infra/prometheus/prometheus.yml) - Metrics scrape rules
+- [Grafana Provisioning](infra/grafana/provisioning/) - Dashboards & datasources
 
-**Domain Index**: [docs/tutorials/INDEX.md](docs/tutorials/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/6_infrastructure/INDEX.md](docs/domains/6_infrastructure/INDEX.md)
 
 ---
 
-### 🛡️ Risk & Compliance
+### ✅ Standards & Quality
 
-**Description**: Risk management, position sizing, drawdown controls, and regulatory compliance.
+**Description**: Engineering standards, quality baselines, and backlog tracking.
 
-**Keywords**: risk, compliance, position-sizing, drawdown, limits, controls, regulation
+**Keywords**: standards, quality, codex, evaluation, roadmap, backlog
 
 **Critical Documents**:
-- [Risk Checklist](docs/help/notebooks/risk-checklist.md) - Risk management guidelines
-- [Risk Docs](docs/risk/) - Risk management documentation
-- [Billing](docs/billing.md) - Financial compliance & billing
+- [Engineering Codex](docs/domains/7_standards/codex.md) - Standards & conventions
+- [Project Evaluation](docs/domains/7_standards/project-evaluation.md) - Quality assessment
+- [Standards Roadmap](docs/domains/7_standards/roadmap.md) - Standards planning
+- [Standards Backlog](docs/domains/7_standards/tasks/2025-q4-backlog.md) - Open actions
 
-**Domain Index**: [docs/risk/INDEX.md](docs/risk/INDEX.md) _(placeholder)_
+**Domain Index**: [docs/domains/7_standards/](docs/domains/7_standards/)
 
 ---
 
-### 💬 Community & Governance
+### 🧭 Supporting Domains (indexes pending)
 
-**Description**: Community resources, contribution guidelines, governance, and communication.
+**Description**: Supporting topics awaiting dedicated indexes.
 
-**Keywords**: community, governance, contributions, pull-requests, issues, releases, communications
+**Keywords**: architecture, security, community, quality
 
-**Critical Documents**:
-- [Contributing Guide](CONTRIBUTING.md) - How to contribute
-- [Code of Conduct](CODE_OF_CONDUCT.md) - Community standards
-- [Changelog](CHANGELOG.md) - Release history
-- [Roadmap](docs/ROADMAP.md) - Future plans
-- [Release Highlights](docs/release-highlights/) - Feature announcements
-- [Communications](docs/communications/) - Project updates
-- [Community Docs](docs/community/) - Community resources
-- [AMA Notes](docs/community/ama-notes/) - Ask-me-anything sessions
-- [Governance](docs/governance/) - Project governance
-
-**Domain Index**: [docs/community/INDEX.md](docs/community/INDEX.md) _(placeholder)_
-
----
-
-### 🎨 User Interface
-
-**Description**: Frontend documentation, UI/UX guidelines, and dashboard specifications.
-
-**Keywords**: UI, frontend, dashboard, SPA, web, React, components, design-system
-
-**Critical Documents**:
-- [UI Overview](docs/ui/README.md) - Frontend architecture
-- [Dashboard Overview](docs/ui/web-dashboard-spa-overview.md) - Web dashboard specs
-- [Dashboard Data Contracts](docs/ui/dashboard-data-contracts.md) - API contracts
-- [Dashboard Modernization](docs/ui/dashboard-modernization.md) - UI upgrade plan
-
-**Domain Index**: [docs/ui/INDEX.md](docs/ui/INDEX.md) _(placeholder)_
-
----
-
-### 🏪 Marketplace & Social
-
-**Description**: Marketplace features, social trading, copy-trading, and strategy sharing.
-
-**Keywords**: marketplace, social-trading, copy-trading, subscriptions, listings, Stripe, monetization
-
-**Critical Documents**:
-- [Marketplace](docs/marketplace.md) - Strategy marketplace & listings
-- [Social Features](docs/social.md) - Social trading & collaboration
-- [Billing](docs/billing.md) - Subscription & payment processing
-
-**Domain Index**: [docs/marketplace/INDEX.md](docs/marketplace/INDEX.md) _(placeholder)_
-
----
-
-### 📋 Project Management
-
-**Description**: Project planning, task tracking, sprint reports, and project status.
-
-**Keywords**: project-management, tasks, sprints, milestones, planning, tracking, status
-
-**Critical Documents**:
-- [MVP Checklist](MVP_CHECKLIST.md) - MVP completion status
-- [MVP Next Steps](MVP_NEXT_STEPS.md) - Post-MVP roadmap
-- [Release Highlights 2025-12](docs/release-highlights/2025-12.md) - December 2025 milestones
-- [Tasks](docs/tasks/) - Task tracking & planning
-- [Project Evaluation](docs/project-evaluation.md) - Project assessment
-
-**Domain Index**: [docs/tasks/INDEX.md](docs/tasks/INDEX.md) _(placeholder)_
-
----
-
-### 🧪 Testing & Quality
-
-**Description**: Testing strategies, quality assurance, test automation, and coverage reports.
-
-**Keywords**: testing, QA, pytest, coverage, CI, quality, test-automation, unit-tests, integration-tests
-
-**Critical Documents**:
-- [Test Local Guide](GUIDE_TEST_LOCAL.md) - Local testing setup
-- [Pre-commit Config](.pre-commit-config.yaml) - Code quality hooks
-- [Coverage Config](.coveragerc) - Test coverage settings
-- [AGENTS.md](AGENTS.md) - AI agent testing guidelines
-
-**Domain Index**: [docs/testing/INDEX.md](docs/testing/INDEX.md) _(placeholder)_
-
----
-
-### 📄 Reports & Analytics
-
-**Description**: Reporting APIs, analytics dashboards, performance metrics, and data exports.
-
-**Keywords**: reports, analytics, metrics, KPIs, performance, data-exports, PDF, dashboards
-
-**Critical Documents**:
-- [Reports](docs/reports/) - Report generation & exports
-- [Metrics](docs/metrics/) - Analytics & KPIs
-- [Observability Dashboards](docs/observability/dashboards/) - Visual analytics
-
-**Domain Index**: [docs/reports/INDEX.md](docs/reports/INDEX.md) _(placeholder)_
+- [Architecture](docs/domains/2_architecture/)
+- [Security](docs/domains/4_security/)
+- [Community](docs/domains/5_community/)
+- [Quality](docs/domains/6_quality/)
 
 ---
 
@@ -251,19 +164,19 @@
 - **Infrastructure**: Docker, docker-compose, Makefile
 - **Testing**: pytest, coverage, pre-commit hooks
 - **CI/CD**: GitHub Actions
-- **Frontend**: React (SPA) - see [UI docs](docs/ui/)
+- **Frontend**: React (SPA) - see [WebApp docs](docs/domains/5_webapp/INDEX.md)
 
 ### Common AI Agent Tasks
 
 | Task | Documentation Path | Keywords |
 |------|-------------------|----------|
-| **Add new service** | [Architecture](#-architecture--services) | microservices, FastAPI, Docker |
-| **Modify trading logic** | [Strategies](#-strategies--trading) | algo-engine, backtesting, orders |
-| **Fix authentication** | [Security](#-security--compliance) | Auth0, auth-service, tokens |
-| **Add monitoring** | [Observability](#-observability--monitoring) | metrics, Prometheus, Grafana |
-| **Deploy changes** | [Operations](#-operations--deployment) | Docker, deployment, CI/CD |
-| **Write tests** | [Testing](#-testing--quality) | pytest, coverage, fixtures |
-| **Update UI** | [User Interface](#-user-interface) | React, dashboard, SPA |
+| **Add new service** | [Infrastructure Index](docs/domains/6_infrastructure/INDEX.md) | microservices, FastAPI, Docker |
+| **Modify trading logic** | [Trading Index](docs/domains/1_trading/INDEX.md) | algo-engine, backtesting, orders |
+| **Fix authentication** | [Auth Service](docs/domains/4_platform/auth-service.md) | auth, tokens, sessions |
+| **Add monitoring** | [Observability Stack](docs/domains/3_operations/observability/README.md) | metrics, Prometheus, Grafana |
+| **Deploy changes** | [Operations Index](docs/domains/3_operations/INDEX.md) | Docker, deployment, CI/CD |
+| **Write tests** | [Engineering Codex](docs/domains/7_standards/codex.md) | pytest, coverage, QA |
+| **Update UI** | [WebApp Index](docs/domains/5_webapp/INDEX.md) | React, dashboard, SPA |
 
 ### File Location Patterns
 
@@ -297,11 +210,11 @@ tests/              # Integration & end-to-end tests
 
 ### When to Update Documentation
 
-- **New service**: Update [Architecture](#-architecture--services) and create service doc in `docs/`
-- **New feature**: Update [Feature Overview](README.md#-feature-overview) and relevant domain index
+- **New service**: Update the relevant domain index under `docs/domains/*/INDEX.md`
+- **New feature**: Update [Feature Overview](README.md#-feature-overview) and the matching domain index
 - **Breaking change**: Update [Changelog](CHANGELOG.md) and affected service docs
-- **API change**: Update service doc and [Dashboard Data Contracts](docs/ui/dashboard-data-contracts.md) if applicable
-- **Configuration change**: Update [Quick Start](README.md#-quick-start) or [Operations](#-operations--deployment)
+- **API change**: Update service doc and [Dashboard Data Contracts](docs/domains/5_webapp/ui/dashboard-data-contracts.md) if applicable
+- **Configuration change**: Update [Quick Start](README.md#-quick-start) or [Operations Index](docs/domains/3_operations/INDEX.md)
 
 ### Code Quality Standards
 


### PR DESCRIPTION
## Summary
- refresh root INDEX.md to point to migrated domain docs
- list critical docs per domain with updated paths
- update AI navigation links to new domain structure

Closes #16