### PR TITLE
docs(templates): add documentation templates

### DIFF
--- a/docs/DOCUMENTATION-GUIDE-FOR-AGENTS.md
+++ b/docs/DOCUMENTATION-GUIDE-FOR-AGENTS.md
@@ -230,6 +230,13 @@ status: {draft|review|published|deprecated}
 ---
 ```
 
+### Templates Directory
+
+Reusable templates are available in `docs/templates/`:
+
+- `docs/templates/service-doc-template.md`
+- `docs/templates/guide-template.md`
+
 ### Minimal Valid Example
 
 ```yaml

--- a/docs/templates/guide-template.md
+++ b/docs/templates/guide-template.md
@@ -1,0 +1,48 @@
+---
+title: "Guide Title"
+domain: "domain-key"
+description: "Short description of what the guide covers."
+keywords: [guide, how-to]
+responsible: ["AgentName"]
+status: draft
+last_updated: 2026-01-06
+---
+
+# Guide Title
+
+> **Audience**: Developers / Operators / Users
+> **Owner**: AgentName
+
+## Purpose
+
+Explain the goal of this guide.
+
+## Prerequisites
+
+- Requirement 1
+- Requirement 2
+
+## Step 1: Action
+
+Explain the first step.
+
+```bash
+command --flag value
+```
+
+## Step 2: Action
+
+Continue with the next steps.
+
+## Troubleshooting
+
+- Issue: description
+- Resolution: description
+
+## Next Steps
+
+Link to the next guide or domain index.
+
+## Related Documentation
+
+- [Domain Index](../domains/DOMAIN/INDEX.md)

--- a/docs/templates/service-doc-template.md
+++ b/docs/templates/service-doc-template.md
@@ -1,0 +1,59 @@
+---
+title: "Service Name"
+domain: "domain-key"
+description: "Short summary of the service purpose."
+keywords: [service, api, reference]
+responsible: ["AgentName"]
+status: draft
+last_updated: 2026-01-06
+---
+
+# Service Name
+
+> **Service**: `service_name`
+> **Owner**: AgentName
+> **Default Port**: `0000`
+
+## Overview
+
+Describe what the service does and who depends on it.
+
+## Architecture
+
+- Key components
+- Data stores
+- External dependencies
+
+## API Endpoints
+
+### `GET /health`
+
+Describe the health check behavior.
+
+**Response**:
+```json
+{
+  "status": "ok"
+}
+```
+
+## Configuration
+
+List environment variables or config files.
+
+## Dependencies
+
+- Service A
+- Service B
+
+## Testing
+
+- `make test-service SERVICE=service_name`
+
+## Deployment
+
+Explain how to deploy or restart the service.
+
+## Related Documentation
+
+- [Domain Index](../domains/DOMAIN/INDEX.md)


### PR DESCRIPTION
## Summary
- add service and guide templates under docs/templates/
- update documentation guide to reference templates directory

Closes #18